### PR TITLE
Update: Unix Compatibility Improvements

### DIFF
--- a/include/limits.h
+++ b/include/limits.h
@@ -1,0 +1,6 @@
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <sys/limits.h>
+#define PATH_MAX 4096
+#endif

--- a/include/minibox.h
+++ b/include/minibox.h
@@ -32,13 +32,18 @@
 #include <windows.h>
 #define PATH_MAX MAX_PATH
 #else
+/* local compatibility headers under include to increase UNIX coverage */
+#include "limits.h"
+#include "signals.h"
+#include "stat.h"
+#include "sysmacros.h"
+#include "utmp.h"
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <libgen.h>
-#include <linux/limits.h>
-#include <linux/stat.h>
 #include <pwd.h>
 #include <signal.h>
 #include <stdint.h>
@@ -47,17 +52,16 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/reboot.h>
-#include <sys/stat.h>
+/* For the BSDs, libsysinfo port is required and `-I/usr/local/include` must be added to CFLAGS in Makefile */
 #include <sys/sysinfo.h>
-#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
 #include <termios.h>
 #include <unistd.h>
 #include <utime.h>
-#include <utmp.h>
 #endif
+
 
 #include <stdbool.h>
 #include <stdio.h>

--- a/include/signals.h
+++ b/include/signals.h
@@ -1,0 +1,8 @@
+/* These two signals are missing from the BSDs; define them here with generic equivalents */
+#ifndef SIGSTKFLT
+#define SIGSTKFLT SIGFPE
+#endif
+
+#ifndef SIGPWR
+#define SIGPWR SIGQUIT
+#endif

--- a/include/stat.h
+++ b/include/stat.h
@@ -1,0 +1,4 @@
+#if defined(__linux__)
+#include <linux/stat.h>
+#endif
+#include <sys/stat.h>

--- a/include/sysmacros.h
+++ b/include/sysmacros.h
@@ -1,0 +1,3 @@
+#if defined(__linux__)
+#include <sys/sysmacros.h>
+#endif

--- a/include/utmp.h
+++ b/include/utmp.h
@@ -1,0 +1,29 @@
+#if defined(__linux__)
+#include <utmp.h>
+#else
+#include <utmpx.h>
+
+/* Ported directly from utmpx.h */
+struct utmp {
+	short		ut_type;	/* Type of entry. */
+	struct timeval	ut_tv;		/* Time entry was made. */
+	char		ut_id[8];	/* Record identifier. */
+	pid_t		ut_pid;		/* Process ID. */
+	char		ut_user[32];	/* User login name. */
+	char		ut_line[16];	/* Device name. */
+	char		ut_host[128];	/* Remote hostname. */
+};
+
+inline void setutent() {
+    setutxent();
+}
+
+inline void endutent() {
+    endutxent();
+}
+
+inline struct utmpx* getutent() {
+    return getutxent();
+}
+
+#endif


### PR DESCRIPTION
These changes won't necessarily cover all Unix systems but should cover the BSDs and Macs without too many issues. Linux uses specific headers that most other Unix based systems have moved away from. This also builds without too many issues on both GCC 13 and Clang 17 on FreeBSD 14.0.

Attached is the build log using GCC 13 with only `-I/usr/local/include` added to the Makefile to link everything correctly.

[minibox.log](https://github.com/user-attachments/files/16815133/minibox.log)